### PR TITLE
Serve appshell.html from Rails

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,15 +65,10 @@ module.exports = {
         let distDir = this.readConfig('distDir');
         let files = this.readConfig('distFiles');
         let indexHTML = fs.readFileSync(path.join(distDir, 'index.html'), 'utf8');
-        let appshellHTML = indexHTML;
-        if (typeof this.readConfig('parseAppshell') === 'function') {
-          appshellHTML = this.readConfig('parseAppshell')(appshellHTML);
-        }
         fs.writeFileSync(path.join(distDir, 'manifest.appcache'), this.writeManifest(files));
-        fs.writeFileSync(path.join(distDir, 'appshell.html'), appshellHTML);
         fs.writeFileSync(path.join(distDir, 'index.html'), indexHTML.replace(/<html/i, `<html manifest="${rootURL()}manifest.appcache"`));
         if (context.distFiles) {
-          context.distFiles.push('manifest.appcache', 'appshell.html');
+          context.distFiles.push('manifest.appcache');
         }
       },
 
@@ -105,7 +100,7 @@ module.exports = {
         let loader = fs.readFileSync(require.resolve('loader.js'), 'utf8');
         let src = fs.readFileSync(path.join(__dirname, 'lib', 'bootloader.js'), 'utf8')
           .replace(/MODULE_PREFIX/g, modulePrefix())
-          .replace(/APPSHELL_PATH/g, assetsURL());
+          .replace(/APPSHELL_PATH/g, rootURL());
         return uglify.minify(loader + src, { fromString: true, mangle: true, compress: true }).code;
       }
     });

--- a/lib/bootloader.js
+++ b/lib/bootloader.js
@@ -45,7 +45,7 @@
   // version without applicationCache intercepting us.
   function getShadowIndex(success, failure) {
     var req = new XMLHttpRequest();
-    req.open('GET', 'APPSHELL_PATHappshell.html', true);
+    req.open('GET', 'APPSHELL_PATHappshell', true);
     req.onreadystatechange = function() {
       if (req.readyState === req.DONE) {
         if (req.status === 200) {

--- a/lib/bootloader.js
+++ b/lib/bootloader.js
@@ -45,7 +45,12 @@
   // version without applicationCache intercepting us.
   function getShadowIndex(success, failure) {
     var req = new XMLHttpRequest();
-    req.open('GET', 'APPSHELL_PATHappshell', true);
+    var path = 'APPSHELL_PATHappshell';
+    var query = window.location.search.match(/revision=([^&#]+)/);
+    if (query) {
+      path = path + '?revision=' + query[1];
+    }
+    req.open('GET', path, true);
     req.onreadystatechange = function() {
       if (req.readyState === req.DONE) {
         if (req.status === 200) {


### PR DESCRIPTION
See: https://github.com/ticketsolve/ticketsolve/pull/2509

Mainly since we already have the index loaded from Redis

- Parsing to remove CSP is done in Rails controller already
- Rails controller will also remove `manifest` attribute from `<html>` tag

Bootloader needs to fetch appshell.html with revision key because when the manifest becomes obsolete, the dom is replaced by appshell. Visiting a revision would replace the dom with the current activated html otherwise.